### PR TITLE
Fix a bug that crashes the RevealStateManager

### DIFF
--- a/src/RevealStateManager.ts
+++ b/src/RevealStateManager.ts
@@ -143,6 +143,8 @@ class RevealStateManager {
                             const boundingRect = $el.getBoundingClientRect();
                             const computedStyle = $el.computedStyleMap();
 
+                            if (computedStyle.size === 0) return canvasConfig.cachedStyle;
+
                             const colorStringMatch = computedStyle.get('--reveal-color').toString().match(/\((\d+,\s*\d+,\s*\d+)[\s\S]*?\)/);
 
                             color = colorStringMatch && colorStringMatch.length > 1 ? colorStringMatch[1] : '0, 0, 0';

--- a/src/cssTypedOM.d.ts
+++ b/src/cssTypedOM.d.ts
@@ -44,7 +44,7 @@ interface HTMLElement {
 }
 
 interface StylePropertyMap {
+  readonly size: number;
   get(stylePropertyName: string): CSSUnitValue | CSSKeywordValue;
   set(stylePropertyName: string, value: CSSUnitValue | string): void,
 }
-


### PR DESCRIPTION
`computedStyle.get('anything')` returns `null` when the `<ax-reveal>` element is removed from DOM tree.