### PR TITLE
fix: incorrect usage of Array.prototype.filter

### DIFF
--- a/src/RevealStateManager.ts
+++ b/src/RevealStateManager.ts
@@ -15,6 +15,6 @@ export class RevealStateManager {
     };
 
     removeBoundary = (store: RevealBoundaryStore) => {
-        this._storage = this._storage.filter(x => x === store);
+        this._storage = this._storage.filter(x => x !== store);
     };
 }


### PR DESCRIPTION
`[1,2,3].filter(x=>x===1)` returns `[1]` instead of `[2,3]`

It's also possible to use a `Map` to achieve O(1) removal, but since it's not a performance critical path I didn't fix it that way.